### PR TITLE
Move parse functions from Vec<u8> to [u8].

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub struct Ff4 {
     pub monster_data: monster::MonsterData,
 }
 
-pub fn parse_rom(data: &Vec<u8>) -> Result<Ff4, Box<Error>> {
-    let monster_data = monster::parse(&data)?;
+pub fn parse_rom(data: &[u8]) -> Result<Ff4, Box<Error>> {
+    let monster_data = monster::parse(data)?;
 
     Ok(Ff4 {
         monster_data: monster_data,

--- a/src/monster/mod.rs
+++ b/src/monster/mod.rs
@@ -112,7 +112,7 @@ pub struct MonsterData {
     pub ai: ai::Ai,
 }
 
-pub fn parse(data: &Vec<u8>) -> Result<MonsterData, Box<Error>> {
+pub fn parse(data: &[u8]) -> Result<MonsterData, Box<Error>> {
     let mut name_table = Vec::new();
     let gp_table: Vec<u16>;
     let xp_table: Vec<u16>;
@@ -162,7 +162,7 @@ pub fn parse(data: &Vec<u8>) -> Result<MonsterData, Box<Error>> {
         monsters.push(monster);
     }
 
-    let ai = ai::parse(&data)?;
+    let ai = ai::parse(data)?;
 
     Ok(MonsterData {
         monsters: monsters,


### PR DESCRIPTION
This makes interop with wasm easier.